### PR TITLE
Turn off LED on SIGINT

### DIFF
--- a/Code/C_Code/01.1.1_Blink/Blink.c
+++ b/Code/C_Code/01.1.1_Blink/Blink.c
@@ -6,15 +6,29 @@
 **********************************************************************/
 #include <wiringPi.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
 
 #define  ledPin    0	//define the led pin number
+
+// Signal handler function
+// Handle interrupt, set LED to LOW
+void handle_interrupt(int signal) {
+    printf("Interrupt signal caught. Exiting...\n");
+
+    digitalWrite(ledPin, LOW);
+    
+    exit(0);
+}
 
 void main(void)
 {	
 	printf("Program is starting ... \n");
 	
 	wiringPiSetup();	//Initialize wiringPi.
-	
+
+	signal(SIGINT, handle_interrupt);
+
 	pinMode(ledPin, OUTPUT);//Set the pin mode
 	printf("Using pin%d\n",ledPin);	//Output information on terminal
 	while(1){

--- a/Code/Python_Code/01.1.1_Blink/Blink.py
+++ b/Code/Python_Code/01.1.1_Blink/Blink.py
@@ -26,6 +26,7 @@ def loop():
         time.sleep(1)                   # Wait for 1 second
 
 def destroy():
+    GPIO.output(ledPin, GPIO.LOW)
     GPIO.cleanup()                      # Release all GPIO
 
 if __name__ == '__main__':    # Program entrance


### PR DESCRIPTION
When blinking the LED, the LED will stay on even after the program receives a `SIGINIT`. 

This PR includes a handler for such cases to ensure that the LED is turned off when receiving a `SIGINT`.

Same changed was opened for [WiringPi](https://github.com/WiringPi/WiringPi/pull/180)